### PR TITLE
Terrain and Biome Changes

### DIFF
--- a/common/src/main/resources/data/bygone/dimension/bygone.json
+++ b/common/src/main/resources/data/bygone/dimension/bygone.json
@@ -7,244 +7,64 @@
       "type": "minecraft:multi_noise",
       "biomes": [
         {
-          "biome": "bygone:underhang",
           "parameters": {
-            "temperature": [
-              0.5,
-              1
-            ],
-            "humidity": [
-              -1,
-              1
-            ],
-            "continentalness": [
-              0,
-              1
-            ],
-            "erosion": [
-              -1,
-              1
-            ],
-            "weirdness": [
-              -1,
-              0
-            ],
-            "depth": [
-              -1,
-              1
-            ],
+            "weirdness": [-1, 1],
+            "continentalness": [-1, -0.5],
+            "erosion": [-1, 1],
+            "temperature": [-1, 1],
+            "humidity": [-1, 1],
+            "depth": [-1, 1],
             "offset": 0
-          }
+          },
+          "biome": "bygone:primordial_ocean"
         },
         {
-          "biome": "bygone:underhang",
           "parameters": {
-            "temperature": [
-              -1,
-              -0.5
-            ],
-            "humidity": [
-              -1,
-              1
-            ],
-            "continentalness": [
-              0,
-              1
-            ],
-            "erosion": [
-              -1,
-              1
-            ],
-            "weirdness": [
-              -1,
-              1
-            ],
-            "depth": [
-              -1,
-              1
-            ],
+            "weirdness": [-1, 1],
+            "continentalness": [-0.5, -0.4],
+            "erosion": [-1, 1],
+            "temperature": [-1, 1],
+            "humidity": [-1, 1],
+            "depth": [-1, 1],
             "offset": 0
-          }
+          },
+          "biome": "bygone:primordial_beach"
         },
         {
-          "biome": "bygone:shelfhollow",
           "parameters": {
-            "temperature": [
-              -0.5,
-              0.5
-            ],
-            "humidity": [
-              -1,
-              0
-            ],
-            "continentalness": [
-              0,
-              1
-            ],
-            "erosion": [
-              -1,
-              0
-            ],
-            "weirdness": [
-              -1,
-              1
-            ],
-            "depth": [
-              -1,
-              1
-            ],
+            "weirdness": [-1, 1],
+            "continentalness": [-0.4, 1],
+            "erosion": [-1, 1],
+            "temperature": [-1, 1],
+            "humidity": [-1, -0.5],
+            "depth": [-1, 1],
             "offset": 0
-          }
+          },
+          "biome": "bygone:amber_desert"
         },
         {
-          "biome": "bygone:shelfhollow",
           "parameters": {
-            "temperature": [
-              -0.5,
-              0.5
-            ],
-            "humidity": [
-              -1,
-              0
-            ],
-            "continentalness": [
-              0,
-              1
-            ],
-            "erosion": [
-              0,
-              1
-            ],
-            "weirdness": [
-              -1,
-              1
-            ],
-            "depth": [
-              -1,
-              1
-            ],
+            "weirdness": [-1, 1],
+            "continentalness": [-0.4, 1],
+            "erosion": [-1, 1],
+            "temperature": [-1, 0],
+            "humidity": [-0.5, 1],
+            "depth": [-1, 1],
             "offset": 0
-          }
+          },
+          "biome": "bygone:shelfhollow"
         },
         {
-          "biome": "bygone:underhang",
           "parameters": {
-            "temperature": [
-              -0.5,
-              0.5
-            ],
-            "humidity": [
-              0,
-              1
-            ],
-            "continentalness": [
-              0,
-              1
-            ],
-            "erosion": [
-              -1,
-              0
-            ],
-            "weirdness": [
-              -1,
-              1
-            ],
-            "depth": [
-              -1,
-              1
-            ],
+            "weirdness": [-1, 1],
+            "continentalness": [-0.4, 1],
+            "erosion": [-1, 1],
+            "temperature": [0, 1],
+            "humidity": [-0.5, 1],
+            "depth": [-1, 1],
             "offset": 0
-          }
-        },
-        {
-          "biome": "bygone:underhang",
-          "parameters": {
-            "temperature": [
-              -0.5,
-              0.5
-            ],
-            "humidity": [
-              0,
-              1
-            ],
-            "continentalness": [
-              0,
-              1
-            ],
-            "erosion": [
-              0,
-              1
-            ],
-            "weirdness": [
-              -1,
-              1
-            ],
-            "depth": [
-              -1,
-              1
-            ],
-            "offset": 0
-          }
-        },
-        {
-          "biome": "bygone:amber_desert",
-          "parameters": {
-            "temperature": [
-              -1,
-              1
-            ],
-            "humidity": [
-              -1,
-              1
-            ],
-            "continentalness": [
-              -0.5,
-              0
-            ],
-            "erosion": [
-              -1,
-              1
-            ],
-            "weirdness": [
-              -1,
-              1
-            ],
-            "depth": [
-              -1,
-              1
-            ],
-            "offset": 0
-          }
-        },
-        {
-          "biome": "bygone:primordial_ocean",
-          "parameters": {
-            "temperature": [
-              -1,
-              1
-            ],
-            "humidity": [
-              -1,
-              1
-            ],
-            "continentalness": [
-              -1,
-              -0.5
-            ],
-            "erosion": [
-              -1,
-              1
-            ],
-            "weirdness": [
-              -1,
-              1
-            ],
-            "depth": [
-              -1,
-              1
-            ],
-            "offset": 0
-          }
+          },
+          "biome": "bygone:underhang"
         }
       ]
     }

--- a/common/src/main/resources/data/bygone/tags/block/bygone_carver_replaceables.json
+++ b/common/src/main/resources/data/bygone/tags/block/bygone_carver_replaceables.json
@@ -1,0 +1,27 @@
+{
+  "values": [
+    "bygone:bystone",
+    "bygone:byslate",
+    "bygone:umber",
+    "bygone:amber",
+    "bygone:amberstone",
+    "bygone:pointed_amber",
+    "bygone:cobbled_amber",
+    "bygone:shelf_mold_moss_block",
+    "bygone:shelf_mold_block",
+    "bygone:shelf_mycelium",
+    "bygone:coarse_claystone",
+    "bygone:claystone",
+    "bygone:mossy_claystone",
+    "bygone:primordial_sand",
+    "bygone:oceanstone",
+    "bygone:bystone_iron_ore",
+    "bygone:byslate_iron_ore",
+    "bygone:bystone_copper_ore",
+    "bygone:byslate_copper_ore",
+    "bygone:bystone_coal_ore",
+    "bygone:byslate_coal_ore",
+    "minecraft:moss_block",
+    "minecraft:basalt"
+  ]
+}

--- a/common/src/main/resources/data/bygone/worldgen/biome/amber_desert.json
+++ b/common/src/main/resources/data/bygone/worldgen/biome/amber_desert.json
@@ -1,10 +1,6 @@
 {
   "carvers": {
-    "air": [
-      "minecraft:cave",
-      "minecraft:cave_extra_underground",
-      "minecraft:canyon"
-    ]
+    "air": ["bygone:cave", "bygone:canyon"]
   },
   "downfall": 0.0,
   "effects": {
@@ -34,16 +30,9 @@
   },
   "features": [
     [],
-    [
-    ],
-    [
-      "bygone:amber",
-      "bygone:amber_2",
-      "bygone:amber_blob"
-    ],
-    [
-      "bygone:small_cloud"
-    ],
+    [],
+    ["bygone:amber", "bygone:amber_2", "bygone:amber_blob"],
+    ["bygone:small_cloud"],
     [],
     [],
     [
@@ -57,10 +46,7 @@
       "bygone:ore_copper"
     ],
     [],
-    [
-      "minecraft:spring_water",
-      "minecraft:spring_lava"
-    ],
+    ["minecraft:spring_water", "minecraft:spring_lava"],
     [
       "minecraft:glow_lichen",
       "bygone:creosote_sprouts",
@@ -68,18 +54,14 @@
       "minecraft:patch_grass_badlands",
       "bygone:amber_desert_vegetation"
     ],
-    [
-      "minecraft:freeze_top_layer"
-    ]
+    ["minecraft:freeze_top_layer"]
   ],
   "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
-    "ambient": [
-    ],
+    "ambient": [],
     "axolotls": [],
-    "creature": [
-    ],
+    "creature": [],
     "misc": [],
     "monster": [
       {
@@ -89,9 +71,7 @@
         "weight": 80
       }
     ],
-    "underground_water_creature": [
-
-    ],
+    "underground_water_creature": [],
     "water_ambient": [],
     "water_creature": []
   },

--- a/common/src/main/resources/data/bygone/worldgen/biome/calm.json
+++ b/common/src/main/resources/data/bygone/worldgen/biome/calm.json
@@ -1,10 +1,6 @@
 {
   "carvers": {
-    "air": [
-      "minecraft:cave",
-      "minecraft:cave_extra_underground",
-      "minecraft:canyon"
-    ]
+    "air": ["bygone:cave", "bygone:canyon"]
   },
   "downfall": 1.0,
   "effects": {
@@ -21,17 +17,9 @@
   },
   "features": [
     [],
-    [
-      "minecraft:lake_lava_underground",
-      "minecraft:lake_lava_surface"
-    ],
-    [
-      "minecraft:amethyst_geode"
-    ],
-    [
-      "minecraft:monster_room",
-      "minecraft:monster_room_deep"
-    ],
+    ["minecraft:lake_lava_underground", "minecraft:lake_lava_surface"],
+    ["minecraft:amethyst_geode"],
+    ["minecraft:monster_room", "minecraft:monster_room_deep"],
     [],
     [],
     [
@@ -66,10 +54,7 @@
       "minecraft:disk_gravel"
     ],
     [],
-    [
-      "minecraft:spring_water",
-      "minecraft:spring_lava"
-    ],
+    ["minecraft:spring_water", "minecraft:spring_lava"],
     [
       "bygone:small_cloud",
       "bygone:test_cloud",
@@ -80,9 +65,7 @@
       "minecraft:patch_sugar_cane",
       "minecraft:patch_pumpkin"
     ],
-    [
-      "minecraft:freeze_top_layer"
-    ]
+    ["minecraft:freeze_top_layer"]
   ],
   "has_precipitation": true,
   "spawn_costs": {},

--- a/common/src/main/resources/data/bygone/worldgen/biome/primordial_beach.json
+++ b/common/src/main/resources/data/bygone/worldgen/biome/primordial_beach.json
@@ -1,0 +1,106 @@
+{
+  "carvers": {
+    "air": ["bygone:cave", "bygone:canyon"]
+  },
+  "downfall": 0.5,
+  "effects": {
+    "additions_sound": {
+      "sound": "bygone:ambient.primordial_ocean.additions",
+      "tick_chance": 0.0014
+    },
+    "music": {
+      "max_delay": 24000,
+      "min_delay": 12000,
+      "replace_current_music": false,
+      "sound": "bygone:music.bygone.primordial_ocean"
+    },
+    "fog_color": 488284,
+    "mood_sound": {
+      "block_search_extent": 8,
+      "offset": 2.0,
+      "sound": "minecraft:ambient.cave",
+      "tick_delay": 6000
+    },
+    "sky_color": 6988951,
+    "water_color": 4445678,
+    "water_fog_color": 270131
+  },
+  "features": [
+    [],
+    [],
+    ["minecraft:iceberg_packed", "minecraft:iceberg_blue"],
+    [
+      "bygone:fossil_upper",
+      "bygone:fossil_lower",
+      "minecraft:monster_room",
+      "minecraft:monster_room_deep"
+    ],
+    ["bygone:small_cloud"],
+    [],
+    [
+      "bygone:ore_coal_upper",
+      "bygone:ore_coal_lower",
+      "bygone:ore_iron_upper",
+      "bygone:ore_iron_middle",
+      "bygone:ore_iron_small",
+      "bygone:ore_copper",
+      "bygone:ore_malachite",
+      "minecraft:underwater_magma",
+      "minecraft:disk_sand",
+      "bygone:disk_test",
+      "bygone:disk_gravel"
+    ],
+    [],
+    [
+      "minecraft:spring_water",
+      "minecraft:glowstone_extra",
+      "minecraft:glowstone"
+    ],
+    [
+      "minecraft:jungle_bush",
+      "bygone:primordial_vents",
+      "bygone:patch_blue",
+      "minecraft:glow_lichen",
+      "bygone:charnia",
+      "bygone:coral",
+      "bygone:seagrass_deep",
+      "bygone:seagrass_normal",
+      "bygone:kelp",
+      "minecraft:flower_cherry",
+      "bygone:flower_primordial"
+    ],
+    ["minecraft:freeze_top_layer"]
+  ],
+  "has_precipitation": true,
+  "spawn_costs": {},
+  "spawners": {
+    "ambient": [],
+    "axolotls": [],
+    "creature": [],
+    "misc": [],
+    "monster": [],
+    "underground_water_creature": [],
+    "water_ambient": [],
+    "water_creature": [
+      {
+        "type": "bygone:scuttle",
+        "maxCount": 1,
+        "minCount": 1,
+        "weight": 20
+      },
+      {
+        "type": "bygone:coelacanth",
+        "maxCount": 3,
+        "minCount": 1,
+        "weight": 15
+      },
+      {
+        "type": "bygone:trilobite",
+        "maxCount": 8,
+        "minCount": 4,
+        "weight": 20
+      }
+    ]
+  },
+  "temperature": 0.5
+}

--- a/common/src/main/resources/data/bygone/worldgen/biome/primordial_ocean.json
+++ b/common/src/main/resources/data/bygone/worldgen/biome/primordial_ocean.json
@@ -1,10 +1,6 @@
 {
   "carvers": {
-    "air": [
-      "minecraft:cave",
-      "minecraft:cave_extra_underground",
-      "minecraft:canyon"
-    ]
+    "air": ["bygone:cave", "bygone:canyon"]
   },
   "downfall": 0.5,
   "effects": {
@@ -31,21 +27,15 @@
   },
   "features": [
     [],
-    [
-    ],
-    [
-      "minecraft:iceberg_packed",
-      "minecraft:iceberg_blue"
-    ],
+    [],
+    ["minecraft:iceberg_packed", "minecraft:iceberg_blue"],
     [
       "bygone:fossil_upper",
       "bygone:fossil_lower",
       "minecraft:monster_room",
       "minecraft:monster_room_deep"
     ],
-    [
-      "bygone:small_cloud"
-    ],
+    ["bygone:small_cloud"],
     [],
     [
       "bygone:ore_coal_upper",
@@ -79,28 +69,18 @@
       "minecraft:flower_cherry",
       "bygone:flower_primordial"
     ],
-    [
-      "minecraft:freeze_top_layer"
-    ]
+    ["minecraft:freeze_top_layer"]
   ],
   "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
-    "ambient": [
-
-    ],
+    "ambient": [],
     "axolotls": [],
     "creature": [],
     "misc": [],
-    "monster": [
-
-    ],
-    "underground_water_creature": [
-
-    ],
-    "water_ambient": [
-
-    ],
+    "monster": [],
+    "underground_water_creature": [],
+    "water_ambient": [],
     "water_creature": [
       {
         "type": "bygone:scuttle",

--- a/common/src/main/resources/data/bygone/worldgen/biome/shelfhollow.json
+++ b/common/src/main/resources/data/bygone/worldgen/biome/shelfhollow.json
@@ -1,10 +1,6 @@
 {
   "carvers": {
-    "air": [
-      "minecraft:cave",
-      "minecraft:cave_extra_underground",
-      "minecraft:canyon"
-    ]
+    "air": ["bygone:cave", "bygone:canyon"]
   },
   "downfall": 1.0,
   "effects": {
@@ -40,10 +36,8 @@
   },
   "features": [
     [],
-    [
-    ],
-    [
-    ],
+    [],
+    [],
     [
       "minecraft:monster_room",
       "minecraft:monster_room_deep",
@@ -63,8 +57,7 @@
       "bygone:purple_mushroom_shelf"
     ],
     [],
-    [
-    ],
+    [],
     [
       "bygone:shelfhollow_ceiling_vegetation",
       "bygone:shelfhollow_ceiling_vegetation2",
@@ -88,18 +81,12 @@
   "has_precipitation": true,
   "spawn_costs": {},
   "spawners": {
-    "ambient": [
-
-    ],
+    "ambient": [],
     "axolotls": [],
-    "creature": [
-
-    ],
+    "creature": [],
     "misc": [],
     "monster": [],
-    "underground_water_creature": [
-
-    ],
+    "underground_water_creature": [],
     "water_ambient": [],
     "water_creature": []
   },

--- a/common/src/main/resources/data/bygone/worldgen/biome/underhang.json
+++ b/common/src/main/resources/data/bygone/worldgen/biome/underhang.json
@@ -1,10 +1,6 @@
 {
   "carvers": {
-    "air": [
-      "minecraft:cave",
-      "minecraft:cave_extra_underground",
-      "minecraft:canyon"
-    ]
+    "air": ["bygone:cave", "bygone:canyon"]
   },
   "downfall": 0.5,
   "effects": {
@@ -39,15 +35,10 @@
     "water_fog_color": 329011
   },
   "features": [
+    [],
+    [],
+    ["minecraft:forest_rock"],
     [
-    ],
-    [
-    ],
-    [
-      "minecraft:forest_rock"
-    ],
-    [
-
       "minecraft:monster_room",
       "minecraft:monster_room_deep",
       "bygone:small_cloud"
@@ -63,8 +54,7 @@
       "bygone:ore_copper"
     ],
     [],
-    [
-    ],
+    [],
     [
       "bygone:ancient_flowers",
       "bygone:underhang/medium_underhang_trees",
@@ -79,19 +69,13 @@
       "bygone:underhang_vegetation",
       "bygone:patch_whirliweed"
     ],
-    [
-      "minecraft:brown_mushroom_normal",
-      "minecraft:red_mushroom_normal"
-    ]
+    ["minecraft:brown_mushroom_normal", "minecraft:red_mushroom_normal"]
   ],
   "has_precipitation": false,
   "spawn_costs": {},
   "spawners": {
-    "ambient": [
-    ],
-    "axolotls": [
-
-    ],
+    "ambient": [],
+    "axolotls": [],
     "creature": [
       {
         "type": "bygone:big_beak",
@@ -113,12 +97,8 @@
       }
     ],
     "misc": [],
-    "monster": [
-
-    ],
-    "underground_water_creature": [
-
-    ],
+    "monster": [],
+    "underground_water_creature": [],
     "water_creature": []
   },
   "temperature": 0.5

--- a/common/src/main/resources/data/bygone/worldgen/configured_carver/canyon.json
+++ b/common/src/main/resources/data/bygone/worldgen/configured_carver/canyon.json
@@ -1,0 +1,70 @@
+{
+  "type": "minecraft:canyon",
+  "config": {
+    "debug_settings": {
+      "air_state": {
+        "Name": "minecraft:warped_button",
+        "Properties": {
+          "face": "wall",
+          "facing": "north",
+          "powered": "false"
+        }
+      },
+      "barrier_state": {
+        "Name": "minecraft:glass"
+      },
+      "lava_state": {
+        "Name": "minecraft:orange_stained_glass"
+      },
+      "water_state": {
+        "Name": "minecraft:candle",
+        "Properties": {
+          "candles": "1",
+          "lit": "false",
+          "waterlogged": "false"
+        }
+      }
+    },
+    "lava_level": {
+      "above_bottom": 0
+    },
+    "probability": 0.01,
+    "replaceable": "#bygone:bygone_carver_replaceables",
+    "shape": {
+      "distance_factor": {
+        "type": "minecraft:uniform",
+        "max_exclusive": 1,
+        "min_inclusive": 0.75
+      },
+      "horizontal_radius_factor": {
+        "type": "minecraft:uniform",
+        "max_exclusive": 1,
+        "min_inclusive": 0.75
+      },
+      "thickness": {
+        "type": "minecraft:trapezoid",
+        "max": 6,
+        "min": 0,
+        "plateau": 2
+      },
+      "vertical_radius_center_factor": 0,
+      "vertical_radius_default_factor": 1,
+      "width_smoothness": 3
+    },
+    "vertical_rotation": {
+      "type": "minecraft:uniform",
+      "max_exclusive": 0.125,
+      "min_inclusive": -0.125
+    },
+    "y": {
+      "type": "minecraft:uniform",
+      "max_inclusive": {
+        "below_top": 64
+      },
+      "min_inclusive": {
+        "above_bottom": 8
+      }
+    },
+    "yScale": 3
+  }
+}

--- a/common/src/main/resources/data/bygone/worldgen/configured_carver/cave.json
+++ b/common/src/main/resources/data/bygone/worldgen/configured_carver/cave.json
@@ -1,0 +1,63 @@
+{
+  "type": "minecraft:cave",
+  "config": {
+    "debug_settings": {
+      "air_state": {
+        "Name": "minecraft:crimson_button",
+        "Properties": {
+          "face": "wall",
+          "facing": "north",
+          "powered": "false"
+        }
+      },
+      "barrier_state": {
+        "Name": "minecraft:glass"
+      },
+      "lava_state": {
+        "Name": "minecraft:orange_stained_glass"
+      },
+      "water_state": {
+        "Name": "minecraft:candle",
+        "Properties": {
+          "candles": "1",
+          "lit": "false",
+          "waterlogged": "false"
+        }
+      }
+    },
+    "floor_level": {
+      "type": "minecraft:uniform",
+      "max_exclusive": -0.4,
+      "min_inclusive": -1
+    },
+    "horizontal_radius_multiplier": {
+      "type": "minecraft:uniform",
+      "max_exclusive": 1.4,
+      "min_inclusive": 0.7
+    },
+    "lava_level": {
+      "above_bottom": 8
+    },
+    "probability": 0.15,
+    "replaceable": "#bygone:bygone_carver_replaceables",
+    "vertical_radius_multiplier": {
+      "type": "minecraft:uniform",
+      "max_exclusive": 1.3,
+      "min_inclusive": 0.8
+    },
+    "y": {
+      "type": "minecraft:uniform",
+      "max_inclusive": {
+        "below_top": 64
+      },
+      "min_inclusive": {
+        "above_bottom": 8
+      }
+    },
+    "yScale": {
+      "type": "minecraft:uniform",
+      "max_exclusive": 0.9,
+      "min_inclusive": 0.1
+    }
+  }
+}

--- a/common/src/main/resources/data/bygone/worldgen/density_function/aquifers/fluid_level_spread.json
+++ b/common/src/main/resources/data/bygone/worldgen/density_function/aquifers/fluid_level_spread.json
@@ -1,6 +1,6 @@
 {
   "type": "minecraft:noise",
-  "noise": "minecraft:aquifer_fluid_level_spread",
+  "noise": "bygone:aquifer/fluid_level_spread",
   "xz_scale": 1,
   "y_scale": 0
 }

--- a/common/src/main/resources/data/bygone/worldgen/density_function/biome_parameters/continents.json
+++ b/common/src/main/resources/data/bygone/worldgen/density_function/biome_parameters/continents.json
@@ -2,7 +2,7 @@
   "type": "minecraft:flat_cache",
   "argument": {
     "type": "minecraft:noise",
-    "noise": "minecraft:continentalness",
+    "noise": "bygone:biome_parameters/continentalness",
     "xz_scale": 0.25,
     "y_scale": 0
   }

--- a/common/src/main/resources/data/bygone/worldgen/density_function/biome_parameters/erosion.json
+++ b/common/src/main/resources/data/bygone/worldgen/density_function/biome_parameters/erosion.json
@@ -2,7 +2,7 @@
   "type": "minecraft:flat_cache",
   "argument": {
     "type": "minecraft:noise",
-    "noise": "minecraft:erosion",
+    "noise": "bygone:biome_parameters/erosion",
     "xz_scale": 0.25,
     "y_scale": 0
   }

--- a/common/src/main/resources/data/bygone/worldgen/density_function/biome_parameters/ridges.json
+++ b/common/src/main/resources/data/bygone/worldgen/density_function/biome_parameters/ridges.json
@@ -2,7 +2,7 @@
   "type": "minecraft:flat_cache",
   "argument": {
     "type": "minecraft:noise",
-    "noise": "minecraft:ridge",
+    "noise": "bygone:biome_parameters/ridge",
     "xz_scale": 0.25,
     "y_scale": 0
   }

--- a/common/src/main/resources/data/bygone/worldgen/density_function/biome_parameters/temperature.json
+++ b/common/src/main/resources/data/bygone/worldgen/density_function/biome_parameters/temperature.json
@@ -2,7 +2,7 @@
   "type": "minecraft:flat_cache",
   "argument": {
     "type": "minecraft:noise",
-    "noise": "minecraft:temperature",
+    "noise": "bygone:biome_parameters/temperature",
     "xz_scale": 0.25,
     "y_scale": 0.0
   }

--- a/common/src/main/resources/data/bygone/worldgen/density_function/biome_parameters/vegetation.json
+++ b/common/src/main/resources/data/bygone/worldgen/density_function/biome_parameters/vegetation.json
@@ -2,7 +2,7 @@
   "type": "minecraft:flat_cache",
   "argument": {
     "type": "minecraft:noise",
-    "noise": "minecraft:vegetation",
+    "noise": "bygone:biome_parameters/vegetation",
     "xz_scale": 0.25,
     "y_scale": 0.0
   }

--- a/common/src/main/resources/data/bygone/worldgen/density_function/caves/pillars.json
+++ b/common/src/main/resources/data/bygone/worldgen/density_function/caves/pillars.json
@@ -1,0 +1,50 @@
+{
+  "type": "minecraft:cache_once",
+  "argument": {
+    "type": "minecraft:mul",
+    "argument1": {
+      "type": "minecraft:add",
+      "argument1": {
+        "type": "minecraft:mul",
+        "argument1": 1.4,
+        "argument2": {
+          "type": "minecraft:noise",
+          "noise": "bygone:caves/pillar",
+          "xz_scale": 25,
+          "y_scale": 0.3
+        }
+      },
+      "argument2": {
+        "type": "minecraft:add",
+        "argument1": -1,
+        "argument2": {
+          "type": "minecraft:mul",
+          "argument1": -1,
+          "argument2": {
+            "type": "minecraft:noise",
+            "noise": "bygone:caves/pillar_rareness",
+            "xz_scale": 1,
+            "y_scale": 1
+          }
+        }
+      }
+    },
+    "argument2": {
+      "type": "minecraft:cube",
+      "argument": {
+        "type": "minecraft:add",
+        "argument1": 0.55,
+        "argument2": {
+          "type": "minecraft:mul",
+          "argument1": 0.55,
+          "argument2": {
+            "type": "minecraft:noise",
+            "noise": "bygone:caves/pillar_thickness",
+            "xz_scale": 1,
+            "y_scale": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/common/src/main/resources/data/bygone/worldgen/density_function/caves/spaghetti.json
+++ b/common/src/main/resources/data/bygone/worldgen/density_function/caves/spaghetti.json
@@ -1,0 +1,45 @@
+{
+  "type": "minecraft:cache_once",
+  "argument": {
+    "type": "minecraft:spline",
+    "spline": {
+      "coordinate": "bygone:caves/spaghetti_depth",
+      "points": [
+        {
+          "location": -0.2,
+          "derivative": 0,
+          "value": 1
+        },
+        {
+          "location": 0,
+          "derivative": 0,
+          "value": {
+            "coordinate": "bygone:caves/spaghetti_noise",
+            "points": [
+              {
+                "location": -0.2,
+                "derivative": 0,
+                "value": 1
+              },
+              {
+                "location": 0,
+                "derivative": 0,
+                "value": -1
+              },
+              {
+                "location": 0.2,
+                "derivative": 0,
+                "value": 1
+              }
+            ]
+          }
+        },
+        {
+          "location": 0.2,
+          "derivative": 0,
+          "value": 1
+        }
+      ]
+    }
+  }
+}

--- a/common/src/main/resources/data/bygone/worldgen/density_function/caves/spaghetti_depth.json
+++ b/common/src/main/resources/data/bygone/worldgen/density_function/caves/spaghetti_depth.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:add",
+  "argument1": {
+    "type": "minecraft:y_clamped_gradient",
+    "from_y": 0,
+    "to_y": 320,
+    "from_value": 1,
+    "to_value": -1
+  },
+  "argument2": "bygone:caves/spaghetti_depth_noise"
+}

--- a/common/src/main/resources/data/bygone/worldgen/density_function/caves/spaghetti_depth_noise.json
+++ b/common/src/main/resources/data/bygone/worldgen/density_function/caves/spaghetti_depth_noise.json
@@ -1,0 +1,6 @@
+{
+  "type": "minecraft:noise",
+  "noise": "bygone:caves/spaghetti_depth",
+  "xz_scale": 0.3,
+  "y_scale": 0
+}

--- a/common/src/main/resources/data/bygone/worldgen/density_function/caves/spaghetti_noise.json
+++ b/common/src/main/resources/data/bygone/worldgen/density_function/caves/spaghetti_noise.json
@@ -1,0 +1,6 @@
+{
+  "type": "minecraft:noise",
+  "noise": "bygone:caves/spaghetti",
+  "xz_scale": 0.75,
+  "y_scale": 0
+}

--- a/common/src/main/resources/data/bygone/worldgen/density_function/final_density.json
+++ b/common/src/main/resources/data/bygone/worldgen/density_function/final_density.json
@@ -37,7 +37,7 @@
                   "argument2": {
                     "type": "minecraft:add",
                     "argument1": 23.4375,
-                    "argument2": "minecraft:end/base_3d_noise"
+                    "argument2": "bygone:terrain/final"
                   }
                 }
               }

--- a/common/src/main/resources/data/bygone/worldgen/density_function/ore_vein/gap.json
+++ b/common/src/main/resources/data/bygone/worldgen/density_function/ore_vein/gap.json
@@ -1,6 +1,6 @@
 {
   "type": "minecraft:noise",
-  "noise": "minecraft:ore_gap",
+  "noise": "bygone:ore/gap",
   "xz_scale": 0.2,
   "y_scale": 0.2
 }

--- a/common/src/main/resources/data/bygone/worldgen/density_function/ore_vein/ridged.json
+++ b/common/src/main/resources/data/bygone/worldgen/density_function/ore_vein/ridged.json
@@ -14,7 +14,7 @@
           "max_exclusive": 112,
           "when_in_range": {
             "type": "minecraft:noise",
-            "noise": "minecraft:ore_vein_a",
+            "noise": "bygone:ore/vein_a",
             "xz_scale": 4,
             "y_scale": 4
           },
@@ -33,7 +33,7 @@
           "max_exclusive": 112,
           "when_in_range": {
             "type": "minecraft:noise",
-            "noise": "minecraft:ore_vein_b",
+            "noise": "bygone:ore/vein_b",
             "xz_scale": 4,
             "y_scale": 4
           },

--- a/common/src/main/resources/data/bygone/worldgen/density_function/ore_vein/toggle.json
+++ b/common/src/main/resources/data/bygone/worldgen/density_function/ore_vein/toggle.json
@@ -7,7 +7,7 @@
     "max_exclusive": 112,
     "when_in_range": {
       "type": "minecraft:noise",
-      "noise": "minecraft:ore_veininess",
+      "noise": "bygone:ore/veininess",
       "xz_scale": 1.5,
       "y_scale": 1.5
     },

--- a/common/src/main/resources/data/bygone/worldgen/density_function/terrain/base_3d_noise.json
+++ b/common/src/main/resources/data/bygone/worldgen/density_function/terrain/base_3d_noise.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:cache_once",
+  "argument": {
+    "type": "minecraft:old_blended_noise",
+    "smear_scale_multiplier": 4,
+    "xz_factor": 80,
+    "xz_scale": 0.25,
+    "y_factor": 160,
+    "y_scale": 0.8
+  }
+}

--- a/common/src/main/resources/data/bygone/worldgen/density_function/terrain/final.json
+++ b/common/src/main/resources/data/bygone/worldgen/density_function/terrain/final.json
@@ -1,0 +1,9 @@
+{
+  "type": "minecraft:max",
+  "argument1": {
+    "type": "minecraft:min",
+    "argument1": "bygone:terrain/base_3d_noise",
+    "argument2": "bygone:caves/spaghetti"
+  },
+  "argument2": "bygone:caves/pillars"
+}

--- a/common/src/main/resources/data/bygone/worldgen/noise/aquifer/fluid_level_spread.json
+++ b/common/src/main/resources/data/bygone/worldgen/noise/aquifer/fluid_level_spread.json
@@ -1,0 +1,4 @@
+{
+  "amplitudes": [1],
+  "firstOctave": -5
+}

--- a/common/src/main/resources/data/bygone/worldgen/noise/aquifer_fluid_level_floodedness.json
+++ b/common/src/main/resources/data/bygone/worldgen/noise/aquifer_fluid_level_floodedness.json
@@ -1,8 +1,0 @@
-{
-  "firstOctave": -7,
-  "amplitudes": [
-    1,
-    0,
-    0
-  ]
-}

--- a/common/src/main/resources/data/bygone/worldgen/noise/biome_parameters/continentalness.json
+++ b/common/src/main/resources/data/bygone/worldgen/noise/biome_parameters/continentalness.json
@@ -1,0 +1,4 @@
+{
+  "amplitudes": [1, 0, 1, 1],
+  "firstOctave": -7
+}

--- a/common/src/main/resources/data/bygone/worldgen/noise/biome_parameters/erosion.json
+++ b/common/src/main/resources/data/bygone/worldgen/noise/biome_parameters/erosion.json
@@ -1,0 +1,4 @@
+{
+  "amplitudes": [1, 0, 1, 1],
+  "firstOctave": -7
+}

--- a/common/src/main/resources/data/bygone/worldgen/noise/biome_parameters/ridge.json
+++ b/common/src/main/resources/data/bygone/worldgen/noise/biome_parameters/ridge.json
@@ -1,0 +1,4 @@
+{
+  "amplitudes": [1, 0, 1, 1],
+  "firstOctave": -7
+}

--- a/common/src/main/resources/data/bygone/worldgen/noise/biome_parameters/temperature.json
+++ b/common/src/main/resources/data/bygone/worldgen/noise/biome_parameters/temperature.json
@@ -1,0 +1,4 @@
+{
+  "amplitudes": [1, 0, 1, 1],
+  "firstOctave": -7
+}

--- a/common/src/main/resources/data/bygone/worldgen/noise/biome_parameters/vegetation.json
+++ b/common/src/main/resources/data/bygone/worldgen/noise/biome_parameters/vegetation.json
@@ -1,0 +1,4 @@
+{
+  "amplitudes": [1, 0, 1, 1],
+  "firstOctave": -7
+}

--- a/common/src/main/resources/data/bygone/worldgen/noise/caves/pillar.json
+++ b/common/src/main/resources/data/bygone/worldgen/noise/caves/pillar.json
@@ -1,0 +1,4 @@
+{
+  "amplitudes": [1, 1],
+  "firstOctave": -7
+}

--- a/common/src/main/resources/data/bygone/worldgen/noise/caves/pillar_rareness.json
+++ b/common/src/main/resources/data/bygone/worldgen/noise/caves/pillar_rareness.json
@@ -1,0 +1,4 @@
+{
+  "amplitudes": [1],
+  "firstOctave": -8
+}

--- a/common/src/main/resources/data/bygone/worldgen/noise/caves/pillar_thickness.json
+++ b/common/src/main/resources/data/bygone/worldgen/noise/caves/pillar_thickness.json
@@ -1,0 +1,4 @@
+{
+  "amplitudes": [1],
+  "firstOctave": -8
+}

--- a/common/src/main/resources/data/bygone/worldgen/noise/caves/spaghetti.json
+++ b/common/src/main/resources/data/bygone/worldgen/noise/caves/spaghetti.json
@@ -1,0 +1,4 @@
+{
+  "firstOctave": -7,
+  "amplitudes": [1]
+}

--- a/common/src/main/resources/data/bygone/worldgen/noise/caves/spaghetti_depth.json
+++ b/common/src/main/resources/data/bygone/worldgen/noise/caves/spaghetti_depth.json
@@ -1,0 +1,4 @@
+{
+  "firstOctave": -7,
+  "amplitudes": [1, 0, 1]
+}

--- a/common/src/main/resources/data/bygone/worldgen/noise/ore/gap.json
+++ b/common/src/main/resources/data/bygone/worldgen/noise/ore/gap.json
@@ -1,0 +1,4 @@
+{
+  "amplitudes": [1],
+  "firstOctave": -5
+}

--- a/common/src/main/resources/data/bygone/worldgen/noise/ore/vein_a.json
+++ b/common/src/main/resources/data/bygone/worldgen/noise/ore/vein_a.json
@@ -1,0 +1,4 @@
+{
+  "amplitudes": [1],
+  "firstOctave": -7
+}

--- a/common/src/main/resources/data/bygone/worldgen/noise/ore/vein_b.json
+++ b/common/src/main/resources/data/bygone/worldgen/noise/ore/vein_b.json
@@ -1,0 +1,4 @@
+{
+  "amplitudes": [1],
+  "firstOctave": -7
+}

--- a/common/src/main/resources/data/bygone/worldgen/noise/ore/veininess.json
+++ b/common/src/main/resources/data/bygone/worldgen/noise/ore/veininess.json
@@ -1,0 +1,4 @@
+{
+  "amplitudes": [1],
+  "firstOctave": -8
+}

--- a/common/src/main/resources/data/bygone/worldgen/noise_settings/bygone.json
+++ b/common/src/main/resources/data/bygone/worldgen/noise_settings/bygone.json
@@ -3,7 +3,7 @@
   "disable_mob_generation": false,
   "ore_veins_enabled": false,
   "aquifers_enabled": true,
-  "legacy_random_source": true,
+  "legacy_random_source": false,
   "default_block": {
     "Name": "bygone:bystone"
   },
@@ -86,9 +86,7 @@
         "type": "minecraft:condition",
         "if_true": {
           "type": "minecraft:biome",
-          "biome_is": [
-            "bygone:underhang"
-          ]
+          "biome_is": ["bygone:underhang"]
         },
         "then_run": {
           "type": "minecraft:condition",
@@ -118,7 +116,6 @@
           "surface_depth_multiplier": 1
         },
         "then_run": {
-
           "type": "minecraft:block",
           "result_state": {
             "Name": "bygone:byslate"
@@ -387,7 +384,7 @@
         "type": "minecraft:condition",
         "if_true": {
           "type": "minecraft:biome",
-          "biome_is": ["bygone:primordial_ocean"]
+          "biome_is": ["bygone:primordial_ocean", "bygone:primordial_beach"]
         },
         "then_run": {
           "type": "minecraft:condition",
@@ -430,7 +427,7 @@
         "type": "minecraft:condition",
         "if_true": {
           "type": "minecraft:biome",
-          "biome_is": ["bygone:primordial_ocean"]
+          "biome_is": ["bygone:primordial_ocean", "bygone:primordial_beach"]
         },
         "then_run": {
           "type": "minecraft:sequence",
@@ -447,7 +444,6 @@
               "then_run": {
                 "type": "minecraft:sequence",
                 "sequence": [
-
                   {
                     "type": "minecraft:block",
                     "result_state": {


### PR DESCRIPTION
Changes:
- Biome Redistribution (beach next to ocean, not desert. Desert rarer/smaller, ocean rarer/smaller)
- New biome (`primordial_beach`, just a clone of the `primordial_ocean` rn)
- Terrain has more horizontality
- Pillars/spikes to terrain
- More caves (full carvers/ravines)
- Spaghetti caves
- (Internal) Decoupled terrain/biome noise from the default overworld