### PR TITLE
Amber Desert Changes

### DIFF
--- a/common/src/main/resources/data/bygone/worldgen/biome/amber_desert.json
+++ b/common/src/main/resources/data/bygone/worldgen/biome/amber_desert.json
@@ -37,7 +37,6 @@
     [],
     [
       "bygone:amber_cluster",
-
       "bygone:ore_coal_upper",
       "bygone:ore_coal_lower",
       "bygone:ore_iron_upper",
@@ -47,11 +46,7 @@
     ],
     [],
     ["minecraft:spring_water", "minecraft:spring_lava"],
-    [
-      "minecraft:glow_lichen",
-
-      "bygone:amber_clump"
-    ],
+    ["minecraft:glow_lichen", "bygone:amber_clump"],
     ["minecraft:freeze_top_layer"]
   ],
   "has_precipitation": false,

--- a/common/src/main/resources/data/bygone/worldgen/configured_feature/amber_clump.json
+++ b/common/src/main/resources/data/bygone/worldgen/configured_feature/amber_clump.json
@@ -4,6 +4,7 @@
     "block": "bygone:amber_clump",
     "can_be_placed_on": [
       "bygone:amber_sand",
+      "bygone:amber_sandstone",
       "bygone:bystone",
       "bygone:byslate"
     ],
@@ -11,6 +12,6 @@
     "can_place_on_floor": false,
     "can_place_on_wall": true,
     "chance_of_spreading": 1.0,
-    "search_range": 20
+    "search_range": 24
   }
 }

--- a/common/src/main/resources/data/bygone/worldgen/noise_settings/bygone.json
+++ b/common/src/main/resources/data/bygone/worldgen/noise_settings/bygone.json
@@ -121,10 +121,30 @@
             "secondary_depth_range": 5
           },
           "then_run": {
-            "type": "minecraft:block",
-            "result_state": {
-              "Name": "bygone:amber_sandstone"
-            }
+            "type": "minecraft:sequence",
+            "sequence": [
+              {
+                "type": "minecraft:condition",
+                "if_true": {
+                  "type": "minecraft:noise_threshold",
+                  "max_threshold": 0.0125,
+                  "min_threshold": -0.0125,
+                  "noise": "minecraft:calcite"
+                },
+                "then_run": {
+                  "type": "minecraft:block",
+                  "result_state": {
+                    "Name": "bygone:amberstone"
+                  }
+                }
+              },
+              {
+                "type": "minecraft:block",
+                "result_state": {
+                  "Name": "bygone:amber_sandstone"
+                }
+              }
+            ]
           }
         }
       },
@@ -266,54 +286,11 @@
               {
                 "type": "minecraft:block",
                 "result_state": {
-                  "Name": "bygone:amber_sand"
+                  "Name": "bygone:amber_sandstone"
                 }
               }
             ]
           }
-        }
-      },
-
-      {
-        "type": "minecraft:condition",
-        "if_true": {
-          "type": "minecraft:biome",
-          "biome_is": ["bygone:amber_desert"]
-        },
-        "then_run": {
-          "type": "minecraft:sequence",
-          "sequence": [
-            {
-              "type": "minecraft:condition",
-              "if_true": {
-                "type": "minecraft:noise_threshold",
-                "max_threshold": 1.7976931348623157e308,
-                "min_threshold": 0.21212121212121213,
-                "noise": "minecraft:surface"
-              },
-              "then_run": {
-                "type": "minecraft:block",
-                "result_state": {
-                  "Name": "bygone:amber_sand"
-                }
-              }
-            },
-            {
-              "type": "minecraft:condition",
-              "if_true": {
-                "type": "minecraft:noise_threshold",
-                "max_threshold": 1.7976931348623157e308,
-                "min_threshold": -0.11515151515151514,
-                "noise": "minecraft:surface"
-              },
-              "then_run": {
-                "type": "minecraft:block",
-                "result_state": {
-                  "Name": "bygone:amber_sand"
-                }
-              }
-            }
-          ]
         }
       },
       {

--- a/common/src/main/resources/data/bygone/worldgen/placed_feature/amber_clump.json
+++ b/common/src/main/resources/data/bygone/worldgen/placed_feature/amber_clump.json
@@ -2,15 +2,14 @@
   "feature": "bygone:amber_clump",
   "placement": [
     {
-      "type": "minecraft:count",
-      "count": {
-        "type": "minecraft:uniform",
-        "max_inclusive": 250,
-        "min_inclusive": 204
-      }
+      "type": "minecraft:count_on_every_layer",
+      "count": 10
     },
     {
-      "type": "minecraft:in_square"
+      "type": "minecraft:noise_based_count",
+      "noise_factor": 50,
+      "noise_offset": 0.0,
+      "noise_to_count_ratio": 200
     },
     {
       "type": "minecraft:height_range",


### PR DESCRIPTION
- Modified Amber Clump placement to be larger patches. Note that there is an issue where they can place on the top surface of blocks for some reason, despite this being set to `false` in the file.
- Modified Amber Desert surface rules to remove a redundant section w/ sand and to fix the amberstone bands from not forming (in the code, not functionally present).